### PR TITLE
Added a service.type check so we only get mysql/mariadb connections

### DIFF
--- a/src/db-services.js
+++ b/src/db-services.js
@@ -11,7 +11,7 @@ function get(app, info) {
   if (info.length > 1) {
     // Filter the services down.
     Object.entries(info).forEach(([key, service]) => {
-      if ('external_connection' in service) {
+      if (['mysql', 'mariadb'].includes(service.type) && 'external_connection' in service) {
         dbservice = service
       }
     })


### PR DESCRIPTION
I have a Lando project I've just added `elasticsearch` service to, but it has an `external_connection` set so it got picked up when running `lando dbeaver`. I added a simple check to make sure we're dealing with mariadb/mysql services only.